### PR TITLE
Resume animation when switching view controller like tab bar

### DIFF
--- a/GCProgressSample/GradientCircularProgress/Progress/Core/CircularProgressView.swift
+++ b/GCProgressSample/GradientCircularProgress/Progress/Core/CircularProgressView.swift
@@ -91,6 +91,15 @@ class CircularProgressView: UIView {
         NotificationCenter.default.removeObserver(self)
     }
     
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            Animation().start(gradientLayer)
+        } else {
+            Animation().stop(gradientLayer)
+        }
+    }
+    
     @objc private func viewDidEnterBackground(_ notification: Notification?) {
         Animation().stop(gradientLayer)
     }


### PR DESCRIPTION
Fix animation stops, when pushing navigation controller or tab bar switching in `addSubView` pattern.
