### PR TITLE
iOS_13 edits

### DIFF
--- a/GCProgressSample/GradientCircularProgress/GradientCircularProgress.swift
+++ b/GCProgressSample/GradientCircularProgress/GradientCircularProgress.swift
@@ -70,7 +70,7 @@ extension GradientCircularProgress {
     }
     
     private func getProgressAtRatio(display: Bool, style: StyleProperty) {
-        baseWindow = BaseWindow()
+        baseWindow = BaseWindow(frame: .zero)
         progressViewController = ProgressViewController()
         
         guard let win = baseWindow, let vc = progressViewController else {
@@ -103,7 +103,7 @@ extension GradientCircularProgress {
     }
     
     private func getProgress(message: String?, style: StyleProperty) {
-        baseWindow = BaseWindow()
+        baseWindow = BaseWindow(frame: .zero)
         progressViewController = ProgressViewController()
         
         guard let win = baseWindow, let vc = progressViewController else {


### PR DESCRIPTION
With iOS13 BaseWindow will no longer accept no arguments anymore. This will fix this while keeping iOS12 compatibility.