### PR TITLE
Use a different method to estimate the size which take Font type into account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Pods/
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 Carthage/Checkouts
 Carthage/Build
+
+.DS_Store

--- a/GCProgressSample/GradientCircularProgress/Progress/Core/ProgressAtRatioView.swift
+++ b/GCProgressSample/GradientCircularProgress/Progress/Core/ProgressAtRatioView.swift
@@ -104,8 +104,13 @@ class ProgressAtRatioView: UIView {
         ratioLabel.font = prop.ratioLabelFont
         ratioLabel.textAlignment = NSTextAlignment.right
         ratioLabel.textColor = prop.ratioLabelFontColor
-        ratioLabel.sizeToFit()
+        ratioLabel.frame.size = (ratioLabel.text as! NSString).boundingRect(
+            with: CGSize(width: prop.progressSize, height: CGFloat.infinity),
+            options: .usesLineFragmentOrigin,
+            attributes: [.font: ratioLabel.font],
+            context: nil).size
         ratioLabel.center = center
+        ratioLabel.adjustsFontSizeToFitWidth = true
         
         addSubview(ratioLabel)
     }

--- a/source/Progress/Core/ProgressAtRatioView.swift
+++ b/source/Progress/Core/ProgressAtRatioView.swift
@@ -104,8 +104,13 @@ class ProgressAtRatioView: UIView {
         ratioLabel.font = prop.ratioLabelFont
         ratioLabel.textAlignment = NSTextAlignment.right
         ratioLabel.textColor = prop.ratioLabelFontColor
-        ratioLabel.sizeToFit()
+        ratioLabel.frame.size = (ratioLabel.text as! NSString).boundingRect(
+            with: CGSize(width: prop.progressSize, height: CGFloat.infinity),
+            options: .usesLineFragmentOrigin,
+            attributes: [.font: ratioLabel.font],
+            context: nil).size
         ratioLabel.center = center
+        ratioLabel.adjustsFontSizeToFitWidth = true
         
         addSubview(ratioLabel)
     }


### PR DESCRIPTION
Using custom font mess up the ratio label and it shows truncated text. You can try it by using following code in the sample project:

    var style = styleList[seletedStyleIndex].1
    style.ratioLabelFont = UIFont(name: "Lato-Bold", size: 18.0)
    progressView = progress.showAtRatio(frame: getRect(), display: displayFlag, style: style)
    progressView?.layer.cornerRadius = 12.0
    view.addSubview(progressView!)

<img width=300 src="https://user-images.githubusercontent.com/2628592/80298346-43f21880-8759-11ea-8f20-e6e18e0bfb1d.png" />